### PR TITLE
Force symbols from deploy.rb into strings to be YAML compatible

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -61,7 +61,7 @@ module Database
       @cap.run("cat #{@cap.current_path}/config/database.yml") do |c, s, d|
         @config += d
       end
-      @config = YAML.load(@config)[@cap.rails_env]
+      @config = YAML.load(@config)[@cap.rails_env.to_s]
     end
 
     def dump
@@ -86,7 +86,7 @@ module Database
   class Local < Base
     def initialize(cap_instance)
       super(cap_instance)
-      @config = YAML.load_file(File.join('config', 'database.yml'))[@cap.local_rails_env]
+      @config = YAML.load_file(File.join('config', 'database.yml'))[@cap.local_rails_env.to_s]
       puts "local #{@config}"
     end
 


### PR DESCRIPTION
From:
https://github.com/timkelty/capistrano-db-tasks/pull/1

```
    It's idiomatic Ruby to use symbols when possible. rails_env is usually a symbol in deploy.rb, but using a symbol makes it incompatible with the remote database.yml.

    I've stringified @cap.rails_env to fix that issue, and symbols can be used again.
```
