### PR TITLE
simple quotes, no escape for mysql inline password

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -15,7 +15,7 @@ module Database
 
     def credentials
       if mysql?
-        (@config['username'] ? " -u #{@config['username']} " : '') + (@config['password'] ? " -p\"#{@config['password']}\" " : '') + (@config['host'] ? " -h #{@config['host']}" : '') + (@config['socket'] ? " -S#{@config['socket']}" : '')
+        (@config['username'] ? " -u #{@config['username']} " : '') + (@config['password'] ? " -p'#{@config['password']}' " : '') + (@config['host'] ? " -h #{@config['host']}" : '') + (@config['socket'] ? " -S#{@config['socket']}" : '')
       elsif postgresql?
         (@config['username'] ? " -U #{@config['username']} " : '') + (@config['host'] ? " -h #{@config['host']}" : '')
       end


### PR DESCRIPTION
I feel a bit funny coming up with that but that's the only way it works for me...

mysql client: `mysql  Ver 14.12 Distrib 5.0.95, for redhat-linux-gnu (x86_64) using readline 5.1`
mysql server: `5.6.10 Source distribution`

I made a couple of tests locally too:

```
mysql -h localhost -u root -ppassword       << WORKS
mysql -h localhost -u root -p'password'       << WORKS
mysql -h localhost -u root -p\"password\" << DOESN'T WORK
mysql -h localhost -u root -p\'password\' << DOESN'T WORK
```

so unless someone come out with a nice story, it seems that simple quotes would do !

thx for that gem ;)
