### PR TITLE
Change dump (with clean flag) and import method for psql

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -44,7 +44,7 @@ module Database
       if mysql?
         "mysqldump #{credentials} #{database} --lock-tables=false"
       elsif postgresql?
-        "#{pgpass} pg_dump --no-acl --no-owner #{credentials} #{database}"
+        "#{pgpass} pg_dump --no-acl --no-owner -c #{credentials} #{database}"
       end
     end
 
@@ -52,8 +52,7 @@ module Database
       if mysql?
         "mysql #{credentials} -D #{database} < #{file}"
       elsif postgresql?
-        terminate_connection_sql = "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '#{database}' AND pid <> pg_backend_pid();"
-        "#{pgpass} psql -c \"#{terminate_connection_sql};\" #{credentials}; #{pgpass} dropdb #{credentials} #{database}; #{pgpass} createdb #{credentials} #{database}; #{pgpass} psql #{credentials} -d #{database} < #{file}"
+        "#{pgpass} psql #{credentials} -d #{database} < #{file}"
       end
     end
 


### PR DESCRIPTION
for postgres database, i changed dump with clean flag then import.

normally, we use cap staging db:pull or db:push to sync databases between local and staging for testing, i think this is enough, we don't need to terminate the conection(there is a syntax problem about this, see this issue https://github.com/sgruhier/capistrano-db-tasks/issues/28), dropdb, createdb then import 

what do you think ?
