### PR TITLE
Use port option from database.yml

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -21,11 +21,11 @@ module Database
         credential_params << " -p '#{@config['password']}' " if @config['password']
         credential_params << " -h #{@config['host']} " if @config['host']
         credential_params << " -S #{@config['socket']} " if @config['socket']
-        credential_params << " -P '#{@config['port']} " if @config['port']
+        credential_params << " -P #{@config['port']} " if @config['port']
       elsif postgresql?
         credential_params << " -U #{@config['username']} " if @config['username']
         credential_params << " -h #{@config['host']} " if @config['host']
-        credential_params << " -p '#{@config['port']} " if @config['port']
+        credential_params << " -p #{@config['port']} " if @config['port']
       end
 
       credential_params


### PR DESCRIPTION
capistrano-db-task shouldn't ignore port option from database.yml.
