### PR TITLE
Add option to remove remote dump file after downloading to local

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,8 +30,11 @@ Add to config/deploy.rb:
     # if you haven't already specified
     set :rails_env, "production"
 
-    # if you want to remove the dump file after loading
+    # if you want to remove the local dump file after loading
     set :db_local_clean, true
+
+    # if you want to remove the dump file from the server after downloading
+    set :db_remote_clean, true
 
     # If you want to import assets, you can change default asset dir (default = system)
     # This directory must be in your shared directory on the server


### PR DESCRIPTION
The purpose of this PR is to avoid leaving a bunch of dumps on remote server and hence avoid it running out of space.
I tested in a real project and it worked fine:
![screen](https://cloud.githubusercontent.com/assets/1196663/3130702/eb6ccc30-e7fb-11e3-927f-aed497397a51.png)
