### PR TITLE
Add option to skip data synchronizatio prompt question

### DIFF
--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -7,13 +7,14 @@ set :rails_env, 'production' unless fetch(:rails_env)
 set :db_local_clean, false unless fetch(:db_local_clean)
 set :assets_dir, 'system' unless fetch(:assets_dir)
 set :local_assets_dir, 'public' unless fetch(:local_assets_dir)
+set :skip_data_sync_confirm, (ENV['SKIP_DATA_SYNC_CONFIRM'].to_s.downcase == 'true')
 
 namespace :db do
   namespace :remote do
     desc 'Synchronize your remote database using local database data'
     task :sync do
       on roles(:db) do
-        if Util.prompt 'Are you sure you want to REPLACE THE REMOTE DATABASE with local database'
+        if fetch(:skip_data_sync_confirm) || Util.prompt('Are you sure you want to REPLACE THE REMOTE DATABASE with local database')
           Database.local_to_remote(self)
         end
       end
@@ -25,7 +26,7 @@ namespace :db do
     task :sync do
       on roles(:db) do
         puts "Local database: #{Database::Local.new(self).database}"
-        if Util.prompt 'Are you sure you want to erase your local database with server database'
+        if fetch(:skip_data_sync_confirm) || Util.prompt('Are you sure you want to erase your local database with server database')
           Database.remote_to_local(self)
         end
       end
@@ -45,7 +46,7 @@ namespace :assets do
     task :sync do
       on roles(:app) do
         puts "Assets directories: #{fetch(:assets_dir)}"
-        if Util.prompt "Are you sure you want to erase your server assets with local assets"
+        if fetch(:skip_data_sync_confirm) || Util.prompt("Are you sure you want to erase your server assets with local assets")
           Asset.local_to_remote(self)
         end
       end
@@ -57,7 +58,7 @@ namespace :assets do
     task :sync do
       on roles(:app) do
         puts "Assets directories: #{fetch(:local_assets_dir)}"
-        if Util.prompt "Are you sure you want to erase your local assets with server assets"
+        if fetch(:skip_data_sync_confirm) || Util.prompt("Are you sure you want to erase your local assets with server assets")
           Asset.remote_to_local(self)
         end
       end
@@ -75,7 +76,7 @@ namespace :app do
   namespace :remote do
     desc 'Synchronize your remote assets AND database using local assets and database'
     task :sync do
-      if Util.prompt "Are you sure you want to REPLACE THE REMOTE DATABASE AND your remote assets with local database and assets(#{fetch(:assets_dir)})"
+      if fetch(:skip_data_sync_confirm) || Util.prompt("Are you sure you want to REPLACE THE REMOTE DATABASE AND your remote assets with local database and assets(#{fetch(:assets_dir)})")
         Database.local_to_remote(self)
         Asset.local_to_remote(self)
       end
@@ -87,7 +88,7 @@ namespace :app do
     task :sync do
       puts "Local database     : #{Database::Local.new(self).database}"
       puts "Assets directories : #{fetch(:local_assets_dir)}"
-      if Util.prompt "Are you sure you want to erase your local database AND your local assets with server database and assets(#{fetch(:assets_dir)})"
+      if fetch(:skip_data_sync_confirm) || Util.prompt("Are you sure you want to erase your local database AND your local assets with server database and assets(#{fetch(:assets_dir)})")
         Database.remote_to_local(self)
         Asset.remote_to_local(self)
       end


### PR DESCRIPTION
Hi @sgruhier 
So, I needed to skip the sync confirmation in order to automate a process of refreshing a QA environment database with the Production one, every week.

This worked pretty well.
