### PR TITLE
if db_local_clean is set, remove local db dump after db:push

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -170,6 +170,7 @@ module Database
 
       local_db.dump.upload
       remote_db.load(local_db.output_file, instance.fetch(:db_local_clean))
+      File.unlink(local_db.output_file) if instance.fetch(:db_local_clean)
     end
   end
 


### PR DESCRIPTION
Just switched over to using this gem instead of my own similar tasks. Noticed that the local dump file cleanup does not happen when doing a remote push (as I often do to our staging server). So my directories were starting to fill up with dump files.  With this change, the local dump is removed after the remote push happens, as long as the cleanup option is specified.
