### PR TITLE
Pass --clean to pg_dump to avoid failure later when importing dump

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -64,7 +64,7 @@ module Database
       if mysql?
         "mysqldump #{credentials} #{database} --lock-tables=false"
       elsif postgresql?
-        "#{pgpass} pg_dump --no-acl --no-owner #{credentials} #{database}"
+        "#{pgpass} pg_dump --clean --no-acl --no-owner #{credentials} #{database}"
       end
     end
 


### PR DESCRIPTION
Pass --clean to pg_dump to avoid failure later when importing dump with user that doesn't have permission to drop/create database. Solves #40