### PR TITLE
Allow dump folder to be configurable by user

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -43,7 +43,7 @@ module Database
     end
 
     def output_file
-      @output_file ||= "db/#{database}_#{current_time}.sql.#{compressor.file_extension}"
+      @output_file ||= "#{database}_#{current_time}.sql.#{compressor.file_extension}"
     end
 
     def compressor
@@ -111,7 +111,7 @@ module Database
     end
 
     def dump
-      @cap.execute "cd #{@cap.current_path} && #{dump_cmd} | #{compressor.compress('-', output_file)}"
+      @cap.execute "cd #{@cap.current_path} && #{dump_cmd} | #{compressor.compress('-', dump_file_path)}"
       self
     end
 
@@ -138,7 +138,11 @@ module Database
     private
 
     def dump_file_path
-      "#{@cap.current_path}/#{output_file}"
+      "#{dump_file_folder}/#{output_file}"
+    end
+
+    def dump_file_folder
+      @cap.fetch(:dump_file_folder) || "#{@cap.current_path}/db"
     end
   end
 


### PR DESCRIPTION
- It is not good practice to allow db/ folder to be written to on production server.   This allows me to set the location where the dump file should be created (e.g., /tmp).
