### PR TITLE
Allow to specify privileged user for database drop/create (PostgreSQL only). Solves #40

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,12 @@ Add to config/deploy.rb:
     # if you prefer bzip2/unbzip2 instead of gzip
     set :compressor, :bzip2
 
+    # If you want to use privileged user to drop/create database on remote or local host (PostgreSQL only)
+    set :db_remote_superuser, 'postgres'
+    set :db_remote_superuser_password, 'secret'
+    set :db_local_superuser, 'postgres'
+    set :db_local_superuser_password, 'secret'
+
 ```
 
 Add to .gitignore


### PR DESCRIPTION
I'm surprised why so much people use privileged user for database access from Rails. App database user should not be allowed to drop/create databases. So I added options to specify privileged username and password (PostgreSQL only) for those who use unprivileged user for Rails app:
```
set :db_remote_superuser, 'postgres'
set :db_remote_superuser_password, 'secret'
set :db_local_superuser, 'postgres'
set :db_local_superuser_password, 'secret'
```
