### PR TITLE
Option for setting db bin path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,11 +22,14 @@ Add it as a gem:
     gem "capistrano-db-tasks", require: false
 ```
 
+Add to Capfile:
+```ruby
+    require 'capistrano-db-tasks'
+```
+
 Add to config/deploy.rb:
 
 ```ruby
-    require 'capistrano-db-tasks'
-
     # if you haven't already specified
     set :rails_env, "production"
 
@@ -41,6 +44,10 @@ Add to config/deploy.rb:
 
     # if you want to exclude table data (but not table schema) from dump
     set :db_ignore_data_tables, []
+
+    # if you want to define a custom bin path for your database installation
+    set :db_remote_bin_path, '/software/postgresql-9.4.5/bin'    
+    set :db_local_bin_path, '/software/postgresql-9.4.5/bin'    
 
     # If you want to import assets, you can change default asset dir (default = system)
     # This directory must be in your shared directory on the server

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -170,7 +170,7 @@ module Database
     def load(file, cleanup)
       unzip_file = File.join(File.dirname(file), File.basename(file, ".#{compressor.file_extension}"))
       # system("bunzip2 -f #{file} && bundle exec rake db:drop db:create && #{import_cmd(unzip_file)} && bundle exec rake db:migrate")
-      @cap.info "executing local: #{compressor.decompress(file)}" && #{import_cmd(unzip_file)}"
+      @cap.info "executing local: #{compressor.decompress(file)} && #{import_cmd(unzip_file)}"
       system("#{compressor.decompress(file)} && #{import_cmd(unzip_file)}")
       if cleanup
         @cap.info "removing #{unzip_file}"


### PR DESCRIPTION
My hosting environment hosts multiple rails applications, which run on different versions of postgres. The default available pg_dump is bundled with 7.4, while the database I'd like to pull is running on 9.4. Therefore, I added an option to specify the db server's bin path to resolve this.

Other changes:
- A db:pull yielded 'INFO true' somewhere near the end. I added some missing parenthesis.
- README update: documented the new option. Finally, all my capistrano3 requires are in Capfile, therefore I think the gem require should be in there as well.
