### PR TITLE
Adds a task using a local file (Closes #85)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,48 +19,48 @@ Install
 Add it as a gem:
 
 ```ruby
-    gem "capistrano-db-tasks", require: false
+gem "capistrano-db-tasks", require: false
 ```
 
 Add to config/deploy.rb:
 
 ```ruby
-    require 'capistrano-db-tasks'
+require 'capistrano-db-tasks'
 
-    # if you haven't already specified
-    set :rails_env, "production"
+# if you haven't already specified
+set :rails_env, "production"
 
-    # if you want to remove the local dump file after loading
-    set :db_local_clean, true
+# if you want to remove the local dump file after loading
+set :db_local_clean, true
 
-    # if you want to remove the dump file from the server after downloading
-    set :db_remote_clean, true
+# if you want to remove the dump file from the server after downloading
+set :db_remote_clean, true
 
-    # if you want to exclude table from dump
-    set :db_ignore_tables, []
+# if you want to exclude table from dump
+set :db_ignore_tables, []
 
-    # if you want to exclude table data (but not table schema) from dump
-    set :db_ignore_data_tables, []
+# if you want to exclude table data (but not table schema) from dump
+set :db_ignore_data_tables, []
 
-    # If you want to import assets, you can change default asset dir (default = system)
-    # This directory must be in your shared directory on the server
-    set :assets_dir, %w(public/assets public/att)
-    set :local_assets_dir, %w(public/assets public/att)
+# If you want to import assets, you can change default asset dir (default = system)
+# This directory must be in your shared directory on the server
+set :assets_dir, %w(public/assets public/att)
+set :local_assets_dir, %w(public/assets public/att)
 
-    # if you want to work on a specific local environment (default = ENV['RAILS_ENV'] || 'development')
-    set :locals_rails_env, "production"
+# if you want to work on a specific local environment (default = ENV['RAILS_ENV'] || 'development')
+set :locals_rails_env, "production"
 
-    # if you are highly paranoid and want to prevent any push operation to the server
-    set :disallow_pushing, true
+# if you are highly paranoid and want to prevent any push operation to the server
+set :disallow_pushing, true
 
-    # if you prefer bzip2/unbzip2 instead of gzip
-    set :compressor, :bzip2
-
+# if you prefer bzip2/unbzip2 instead of gzip
+set :compressor, :bzip2
 ```
 
 Add to .gitignore
-```yml
-    /db/*.sql
+
+```
+db/*.sql
 ```
 
 
@@ -69,21 +69,42 @@ Add to .gitignore
 Available tasks
 ===============
 
-    app:local:sync      || app:pull     # Synchronize your local assets AND database using remote assets and database
-    app:remote:sync     || app:push     # Synchronize your remote assets AND database using local assets and database
+```
+app:local:sync      || app:pull     # Synchronize your local assets AND database using remote assets and database
+app:remote:sync     || app:push     # Synchronize your remote assets AND database using local assets and database
 
-    assets:local:sync   || assets:pull  # Synchronize your local assets using remote assets
-    assets:remote:sync  || assets:push  # Synchronize your remote assets using local assets
+assets:local:sync   || assets:pull  # Synchronize your local assets using remote assets
+assets:remote:sync  || assets:push  # Synchronize your remote assets using local assets
 
-    db:local:sync       || db:pull      # Synchronize your local database using remote database data
-    db:remote:sync      || db:push      # Synchronize your remote database using local database data
+db:local:sync       || db:pull      # Synchronize your local database using remote database data
+db:remote:sync      || db:push      # Synchronize your remote database using local database data
+
+db:local:load                       # Synchronize your local database using local database dump file
+```
 
 Example
 =======
 
-    cap db:pull
-    cap production db:pull # if you are using capistrano-ext to have multistages
+#### Replace your local database with the production database
 
+This use case allows you to have the same data on your machine as your production.
+You then can reproduce or test things before to apply to your production.
+
+```bash
+$ cap db:pull
+$ cap production db:pull # if you are using capistrano-ext to have multistages
+```
+
+#### Replace your local database using a dump file stored on your machine
+
+In case you have a dump file on your machine (you used `db:pull` and kept some files)
+and you want to replay one of them, you can use the `db:local:load`:
+
+```
+$ cap development db:local:load DUMP_FILE=db/yellow_production_2016-04-12-150434.sql
+```
+(You have to create a `config/deploy/development.rb` file containing
+`set :stage, :development` at least in order to get this working)
 
 Contributors
 ============
@@ -92,6 +113,7 @@ Contributors
 * bigfive    (http://github.com/bigfive)
 * jakemauer  (http://github.com/jakemauer)
 * tjoneseng  (http://github.com/tjoneseng)
+* zedtux     (http://github.com/zedtux)
 
 TODO
 ====

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -175,12 +175,23 @@ module Database
     end
   end
 
-
   class << self
-    def check(local_db, remote_db)
-      unless (local_db.mysql? && remote_db.mysql?) || (local_db.postgresql? && remote_db.postgresql?)
-        raise 'Only mysql or postgresql on remote and local server is supported'
+    def check(local_db, remote_db = nil)
+      if mysql_db_valid?(local_db, remote_db) ||
+         postgresql_db_valid?(local_db, remote_db)
+        return
       end
+
+      fail 'Only mysql or postgresql on remote and local server is supported'
+    end
+
+    def mysql_db_valid?(local_db, remote_db)
+      local_db.mysql? && (remote_db.nil? || remote_db && remote_db.mysql?)
+    end
+
+    def postgresql_db_valid?(local_db, remote_db)
+      local_db.postgresql? &&
+        (remote_db.nil? || (remote_db && remote_db.postgresql?))
     end
 
     def remote_to_local(instance)
@@ -207,6 +218,13 @@ module Database
       remote_db.load(local_db.output_file, instance.fetch(:db_local_clean))
       File.unlink(local_db.output_file) if instance.fetch(:db_local_clean)
     end
-  end
 
+    def local_to_local(instance, dump_file)
+      local_db = Database::Local.new(instance)
+
+      check(local_db)
+
+      local_db.load(dump_file, instance.fetch(:db_local_clean))
+    end
+  end
 end

--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -42,6 +42,27 @@ namespace :db do
         end
       end
     end
+
+    desc 'Replace your local database using a dump file from the DUMP_FILE ' \
+         'environment variable'
+    task :load do
+      run_locally do
+        if ENV['DUMP_FILE'].nil?
+          fail 'You muse give a dump file using the DUMP_FILE environment ' \
+               'variable'
+        end
+
+        unless File.exist?(ENV['DUMP_FILE'])
+          fail "File #{ENV['DUMP_FILE']} doesn't exists"
+        end
+
+        if fetch(:skip_data_sync_confirm) ||
+           Util.prompt('Are you sure you want to erase your local database ' \
+                       "with the dump file #{ENV['DUMP_FILE']}")
+          Database.local_to_local(self, ENV['DUMP_FILE'])
+        end
+      end
+    end
   end
 
   desc 'Synchronize your local database using remote database data'


### PR DESCRIPTION
This allows someone to re-use a dump file stored in the `db/` folder passing the dump file path using the environment variable `DUMP_FILE` in order to replace his local database
