### PR TITLE
Add postigs to allowed PG adapters

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -12,7 +12,7 @@ module Database
     end
 
     def postgresql?
-      %w(postgresql pg).include? @config['adapter']
+      %w(postgresql pg postgis).include? @config['adapter']
     end
 
     def credentials


### PR DESCRIPTION
This small PR adds `postgis` addapter to the allowed `postgresql` adapters (supplementing `pg` and `postgresql`).