### PR TITLE
specify database for pg_terminate_backend

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -73,7 +73,7 @@ module Database
         "mysql #{credentials} -D #{database} < #{file}"
       elsif postgresql?
         terminate_connection_sql = "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '#{database}' AND pid <> pg_backend_pid();"
-        "#{pgpass} psql -c \"#{terminate_connection_sql};\" #{credentials}; #{pgpass} dropdb #{credentials} #{database}; #{pgpass} createdb #{credentials} #{database}; #{pgpass} psql #{credentials} -d #{database} < #{file}"
+        "#{pgpass} psql -c \"#{terminate_connection_sql};\" #{credentials} #{database}; #{pgpass} dropdb #{credentials} #{database}; #{pgpass} createdb #{credentials} #{database}; #{pgpass} psql #{credentials} -d #{database} < #{file}"
       end
     end
 


### PR DESCRIPTION
The `psql -c \"#{terminate_connection_sql};\"` was running without a database specified. Postgres attempts to handle this by connecting to a database with the same name as the current user. If you don't have a database with that name, you get an error:

```
      executing local: bunzip2 -f db/xyz_production_2016-08-19-121802.sql.bz2 &&  psql -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'xyz_development' AND pid <> pg_backend_pid();;" ;  dropdb  xyz_development;  createdb  xyz_development;  psql  -d xyz_development < db/xyz_production_201…

psql: FATAL:  database "steven" does not exist
```

This change supplies the name of a valid database so the `terminate_backend` command will run without error.

```
      executing local: bunzip2 -f db/xyz_production_2016-08-19-122005.sql.bz2 &&  psql -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'xyz_development' AND pid <> pg_backend_pid();;"  xyz_development;  dropdb  xyz_development;  createdb  xyz_development;  psql  -d xyz_development < db/di…
 pg_terminate_backend
----------------------
(0 rows)
```

Closes #84 