### PR TITLE
Add task for pulling down remote db without loading locally

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -215,6 +215,18 @@ module Database
       remote_db.load(local_db.output_file, instance.fetch(:db_local_clean))
       File.unlink(local_db.output_file) if instance.fetch(:db_local_clean)
     end
+
+    def remote_backup(instance)
+      remote_db = Database::Remote.new(instance)
+      remote_db.dump.download
+
+      file       = remote_db.output_file
+      unzip_file = File.join(File.dirname(file), File.basename(file, '.bz2'))
+      backup_dir = instance.fetch(:db_backup_dir)
+
+      instance.logger.info("Unzipping database backup and storing in #{backup_dir}")
+      system("bunzip2 -f #{file} && mkdir -p #{backup_dir} && mv #{unzip_file} #{backup_dir}")
+    end
   end
 
 end

--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -13,6 +13,7 @@ set :local_assets_dir, 'public' unless fetch(:local_assets_dir)
 set :skip_data_sync_confirm, (ENV['SKIP_DATA_SYNC_CONFIRM'].to_s.downcase == 'true')
 set :disallow_pushing, false unless fetch(:disallow_pushing)
 set :compressor, :gzip unless fetch(:compressor)
+set :db_backup_dir, 'db/backups' unless fetch(:db_backup_dir)
 
 namespace :capistrano_db_tasks do
   task :check_can_push do
@@ -27,6 +28,14 @@ namespace :db do
       on roles(:db) do
         if fetch(:skip_data_sync_confirm) || Util.prompt('Are you sure you want to REPLACE THE REMOTE DATABASE with local database')
           Database.local_to_remote(self)
+        end
+      end
+    end
+
+    desc 'Create a database backup remote database data'
+      task :backup do
+        on roles(:db) do
+          Database.remote_backup(instance)
         end
       end
     end
@@ -46,6 +55,9 @@ namespace :db do
 
   desc 'Synchronize your local database using remote database data'
   task :pull => "db:local:sync"
+
+  desc 'Create a database backup remote database data'
+  task :backup => "db:remote:backup"
 
   desc 'Synchronize your remote database using local database data'
   task :push => "db:remote:sync"


### PR DESCRIPTION
This is an awesome tool, thanks for the work on it so far.

I often just need to create a backup without loading the database onto my local environment though. A nice thing to have automatically run in front of deploys in case things go poorly.