### PR TITLE
Fix rbenv/rvm and capistrano-db-tasks

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -155,11 +155,11 @@ module Database
     def initialize(cap_instance)
       super(cap_instance)
       @cap.info "Loading local database config"
-      dirty_config_content = @cap.run_locally do
-        capture(:rails, "runner \"puts '#{DBCONFIG_BEGIN_FLAG}' + ActiveRecord::Base.connection.instance_variable_get(:@config).to_yaml + '#{DBCONFIG_END_FLAG}'\"")
-      end
-      # Remove all warnings, errors and artefacts produced by bunlder, rails and other useful tools
-      config_content = dirty_config_content.match(/#{DBCONFIG_BEGIN_FLAG}(.*?)#{DBCONFIG_END_FLAG}/m)[1]
+      command = "#{Dir.pwd}/bin/rails runner \"puts '#{DBCONFIG_BEGIN_FLAG}' + ActiveRecord::Base.connection.instance_variable_get(:@config).to_yaml + '#{DBCONFIG_END_FLAG}'\""
+      stdout, status = Open3.capture2(command)
+      raise "Error running command (status=#{status}): #{command}" if status != 0
+
+      config_content = stdout.match(/#{DBCONFIG_BEGIN_FLAG}(.*?)#{DBCONFIG_END_FLAG}/m)[1]
       @config = YAML.load(config_content).inject({}) { |h, (k, v)| h[k.to_s] = v; h }
     end
 


### PR DESCRIPTION
As mentionned here: https://github.com/capistrano/sshkit/pull/153#issuecomment-56688429 and https://github.com/capistrano/sshkit/pull/24#issuecomment-24621138 by one of Capistrano's maintainer, the `run_locally` feature is not a very good idea and shouldn't be used.

This PR removes the use of it in Initializing Database::Local, which is broken when used in conjunction with capistrano-rvm/rbenv (it'll use the sshkit configs for the rails command which are set up to use the remote rbenv/rvm config)