### PR TITLE
Fix error of loading config file, when a project have a path with spaces in folder names

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -156,7 +156,8 @@ module Database
     def initialize(cap_instance)
       super(cap_instance)
       puts "Loading local database config"
-      command = "#{Dir.pwd}/bin/rails runner \"puts '#{DBCONFIG_BEGIN_FLAG}' + ActiveRecord::Base.connection.instance_variable_get(:@config).to_yaml + '#{DBCONFIG_END_FLAG}'\""
+      dir_with_escaped_spaces = Dir.pwd.gsub ' ', '\ '
+      command = "#{dir_with_escaped_spaces}/bin/rails runner \"puts '#{DBCONFIG_BEGIN_FLAG}' + ActiveRecord::Base.connection.instance_variable_get(:@config).to_yaml + '#{DBCONFIG_END_FLAG}'\""
       stdout, status = Open3.capture2(command)
       raise "Error running command (status=#{status}): #{command}" if status != 0
 


### PR DESCRIPTION
For example, if a project in question is located in «/Volumes/Macintosh HD/…», then following error will be occured «sh: /Volumes/Macintosh: No such file or directory» while invoking, e.g. «cap production db:push» command.