### PR TITLE
Add `chronomodel` to list of postgres adapters

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -14,7 +14,7 @@ module Database
     end
 
     def postgresql?
-      %w(postgresql pg postgis).include? @config['adapter']
+      %w(postgresql pg postgis chronomodel).include? @config['adapter']
     end
 
     def credentials


### PR DESCRIPTION
It's this gem here: https://github.com/ifad/chronomodel and it's just postgres


🤔  did I forget to send a PR 17 days ago?