### PR TITLE
Adds a task using a local file (Closes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,26 @@ db:remote:sync      || db:push      # Synchronize your remote database using loc
 
 ## Example
 
-```
+#### Replace your local database with the production database
+
+This use case allows you to have the same data on your machine as your production.
+You then can reproduce or test things before to apply to your production.
+
+```bash
 cap db:pull
 cap production db:pull # if you are using capistrano-ext to have multistages
 ```
+
+#### Replace your local database using a dump file stored on your machine
+
+In case you have a dump file on your machine (you used `db:pull` and kept some files)
+and you want to replay one of them, you can use the `db:local:load`:
+
+```
+cap development db:local:load DUMP_FILE=db/myapp_production_2018-01-10-150434.sql
+```
+(You have to create a `config/deploy/development.rb` file containing
+`set :stage, :development` at least in order to get this working)
 
 ## Contributors
 

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -199,8 +199,20 @@ module Database
   end
 
   class << self
-    def check(local_db, remote_db)
-      raise 'Only mysql or postgresql on remote and local server is supported' unless (local_db.mysql? && remote_db.mysql?) || (local_db.postgresql? && remote_db.postgresql?)
+    def check(local_db, remote_db = nil)
+      return if mysql_db_valid?(local_db, remote_db)
+      return if postgresql_db_valid?(local_db, remote_db)
+
+      raise 'Only mysql or postgresql on remote and local server is supported'
+    end
+
+    def mysql_db_valid?(local_db, remote_db)
+      local_db.mysql? && (remote_db.nil? || remote_db && remote_db.mysql?)
+    end
+
+    def postgresql_db_valid?(local_db, remote_db)
+      local_db.postgresql? &&
+        (remote_db.nil? || (remote_db && remote_db.postgresql?))
     end
 
     def remote_to_local(instance)
@@ -226,6 +238,14 @@ module Database
       local_db.dump.upload
       remote_db.load(local_db.output_file, instance.fetch(:db_local_clean))
       File.unlink(local_db.output_file) if instance.fetch(:db_local_clean)
+    end
+
+    def local_to_local(instance, dump_file)
+      local_db = Database::Local.new(instance)
+
+      check(local_db)
+
+      local_db.load(dump_file, instance.fetch(:db_local_clean))
     end
   end
 end

--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -43,6 +43,27 @@ namespace :db do
         end
       end
     end
+
+    desc 'Replace your local database using a dump file from the DUMP_FILE ' \
+         'environment variable'
+    task :load do
+      run_locally do
+        if ENV['DUMP_FILE'].nil?
+          raise 'You must give a dump file using the DUMP_FILE environment ' \
+                'variable'
+        end
+
+        unless File.exist?(ENV['DUMP_FILE'])
+          raise "File #{ENV['DUMP_FILE']} doesn't exists"
+        end
+
+        if fetch(:skip_data_sync_confirm) ||
+           Util.prompt('Are you sure you want to erase your local database ' \
+                       "with the dump file #{ENV['DUMP_FILE']}")
+          Database.local_to_local(self, ENV['DUMP_FILE'])
+        end
+      end
+    end
   end
 
   desc 'Synchronize your local database using remote database data'


### PR DESCRIPTION
This allow someone to re-use a dump file stored in the db/ folder, passing the dump file path via the environment variable DUMP_FILE, in order to replace his local database.

This PR replaces #88.