### PR TITLE
Fix local to remote dears path

### DIFF
--- a/lib/capistrano-db-tasks/asset.rb
+++ b/lib/capistrano-db-tasks/asset.rb
@@ -23,7 +23,7 @@ module Asset
     local_dirs = [cap.fetch(:local_assets_dir)].flatten
 
     dirs.each_index do |idx|
-      system("rsync -a --del -L -K -vv --progress --rsh='ssh -p #{port}' ./#{dirs[idx]} #{user}@#{server}:#{cap.current_path}/#{local_dirs[idx]}")
+      system("rsync -a --del -L -K -vv --progress --rsh='ssh -p #{port}' #{local_dirs[idx]} #{user}@#{server}:#{cap.current_path}/#{dirs[idx]}")
     end
   end
 


### PR DESCRIPTION
.1 Firstly `./` on my local env ( Sierra 10.13.2 and Ruby 2.5.0  ) produce this error:
```
rsync: link_stat "/Users/margo/project/./public/storage" failed: No such file or directory (2)
``` 
.2 Then, I think we should copy files from `local_dirs` to `dirs`, and not vice versa.

P.S. thanks for this awesome useful gem! :)