### PR TITLE
Ensured that adapter checks work if the adapter name contains extra space

### DIFF
--- a/capistrano-db-tasks.gemspec
+++ b/capistrano-db-tasks.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "capistrano", ">= 3.0.0"
+  gem.add_development_dependency "rspec"
+
 end

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -10,11 +10,12 @@ module Database
     end
 
     def mysql?
-      @config['adapter'] =~ /^mysql/
+      @config['adapter'].strip =~ /^mysql/
     end
 
     def postgresql?
-      %w(postgresql pg postgis chronomodel).include? @config['adapter']
+       adapter = @config['adapter'].strip
+       %{postgresql pg}.include? adapter
     end
 
     def credentials

--- a/spec/ensure_adapters_work_with_extra_space_spec.rb
+++ b/spec/ensure_adapters_work_with_extra_space_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+require "capistrano"
+
+describe Database::Base do
+  
+  let(:base) { 
+    Database::Base.new({}) 
+  }
+  
+  describe "identifying mysql adapter" do
+
+    context "when mysql" do
+      it "it is positive" do
+        base.config = { "adapter" => "mysql" }
+        expect(base.mysql?).to be_truthy
+      end
+    end
+    
+    context "when mysql with extra space" do
+      it "it is positive" do
+        base.config = { "adapter" => "  mysql  " }
+        expect(base.mysql?).to be_truthy
+      end
+    end
+    
+    context "when postgresql" do
+      it "it is positive" do
+        base.config = { "adapter" => "postgresql" }
+        expect(base.mysql?).to be_falsey
+      end
+    end
+    
+    context "when pg" do
+      it "it is positive" do
+        base.config = { "adapter" => "pg" }
+        expect(base.mysql?).to be_falsey
+      end
+    end
+    
+    context "when something else" do
+      it "it is positive" do
+        base.config = { "adapter" => "foo" }
+        expect(base.mysql?).to be_falsey
+      end
+    end
+
+  end
+
+  describe "identifying postgres adapter" do
+    
+    context "when postgresql" do
+      it "it is positive" do
+        base.config = { "adapter" => "postgresql" }
+        expect(base.postgresql?).to be_truthy
+      end
+    end
+    
+    context "when postgresql with extra space" do
+      it "it is positive" do
+        base.config = { "adapter" => "  postgresql  " }
+        expect(base.postgresql?).to be_truthy
+      end
+    end
+    
+    context "when pg" do
+      it "it is positive" do
+        base.config = { "adapter" => "pg" }
+        expect(base.postgresql?).to be_truthy
+      end
+    end
+    
+    context "when pg with extra space" do
+      it "it is positive" do
+        base.config = { "adapter" => "  pg  " }
+        expect(base.postgresql?).to be_truthy
+      end
+    end
+    
+    context "when mysql" do
+      it "it is positive" do
+        base.config = { "adapter" => "mysq" }
+        expect(base.postgresql?).to be_falsey
+      end
+    end
+    
+    context "when something else" do
+      it "it is positive" do
+        base.config = { "adapter" => "foo" }
+        expect(base.postgresql?).to be_falsey
+      end
+    end
+    
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+require 'bundler/setup'
+Bundler.setup
+
+#
+# “Note: May need to be looked at if additional tests added”
+#
+ENV['RAILS_ENV'] = 'development'
+
+class Object 
+  def fetch(x)
+    false
+  end
+  def set(x, y)
+    true
+  end
+  def namespace(x)
+    true
+  end
+end
+#
+# end ”Note: May need to be looked at if additional tests added”
+#
+
+require 'capistrano-db-tasks'
+
+RSpec.configure do |config|
+end

--- a/test/capistrano_db_tasks_test.rb
+++ b/test/capistrano_db_tasks_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class CapistranoDbTasksTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,0 @@
-require 'rubygems'
-require 'active_support'
-require 'active_support/test_case'


### PR DESCRIPTION
Re: [#127 - Strip adapter check?](https://github.com/sgruhier/capistrano-db-tasks/issues/127) - checking the adapter name should still work if it contains space