### PR TITLE
Add support for specifying extra command line options during database dump and load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/sgruhier/capistrano-db-tasks/compare/v0.6...HEAD
 
 * Your contribution here!
+* Add support for passing extra options to the database dump and load commands (@someonewithpc)
 * Added support for [zstd compressor](http://facebook.github.io/zstd/) (@ocha)
 
 # 0.6 (Dec 14 2016)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ set :disallow_pushing, true
 
 # if you prefer bzip2/unbzip2 instead of gzip
 set :compressor, :bzip2
+
+# if you need to add extra command line options to the import or export commands
+set :db_dump_extra_opts, ""
+set :db_import_extra_opts, ""
 ```
 
 Add to .gitignore

--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -14,6 +14,8 @@ set :local_assets_dir, 'public' unless fetch(:local_assets_dir)
 set :skip_data_sync_confirm, ENV['SKIP_DATA_SYNC_CONFIRM'].to_s.casecmp('true').zero?
 set :disallow_pushing, false unless fetch(:disallow_pushing)
 set :compressor, :gzip unless fetch(:compressor)
+set :db_dump_extra_opts, '' unless fetch(:db_dump_extra_opts)
+set :db_import_extra_opts, '' unless fetch(:db_import_extra_opts)
 
 namespace :capistrano_db_tasks do
   task :check_can_push do

--- a/lib/capistrano-db-tasks/version.rb
+++ b/lib/capistrano-db-tasks/version.rb
@@ -1,3 +1,3 @@
 module CapistranoDbTasks
-  VERSION = "0.6".freeze
+  VERSION = "0.7".freeze
 end


### PR DESCRIPTION
I'm running into an error that can be solved by adding `--complete-insert` to the `mysqldump` command, caused by having a structure where a non-unique identifier follows the actual identifier:

```
CREATE TABLE `amendment_events` (
  `id` int NOT NULL AUTO_INCREMENT,
  `amendment_id` int DEFAULT NULL,
  PRIMARY KEY (`id`),
  # ...
) #...
```

And the generated dump has

```
INSERT INTO `amendment_events` VALUES
(44,'2014-06-06 06:42:40',NULL,44,'new',18),
```

i.e., the columns are not specified, but `44` actually refers to `amendment_id`, not `id`, which is leading to errors when importing. 

Note: We're using a relatively old version of MySQL, so I don't know if this is a known bug